### PR TITLE
Fix mute_volume function

### DIFF
--- a/custom_components/hifiberry/media_player.py
+++ b/custom_components/hifiberry/media_player.py
@@ -219,11 +219,13 @@ class HifiberryMediaPlayer(MediaPlayerEntity):
 
     async def async_mute_volume(self, mute):
         """Mute. Emulated with set_volume_level."""
-        if mute:
-            self._muted_volume = self.volume_level
-            await self._audiocontrol2.volume(0)
-        await self._audiocontrol2.volume(int(self._muted_volume * 100))
-        self._muted = mute
+        if mute != self._muted:
+            if mute:
+                self._muted_volume = self.volume_level
+                await self._audiocontrol2.volume(0)
+            else:
+                await self._audiocontrol2.volume(int(self._muted_volume * 100))
+            self._muted = mute
 
     async def async_turn_off(self):
         return await self._audiocontrol2.poweroff()


### PR DESCRIPTION
Double mute or double unmute was resulting in unexpected behaviour, i.e. unmute when it was not muted has restored some older volume, double muting made the mute/unmute button useless. So it is now only called when the state changes. (Although it might cause some problems if the volume is increased manually from 0 after using the mute button.)

Resetting the volume should only be called if unmuting (I don't know why this was working in the first place, can you shed some light on it).