### PR TITLE
Replace deprated `async_setup_platforms`

### DIFF
--- a/custom_components/hifiberry/__init__.py
+++ b/custom_components/hifiberry/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DATA_HIFIBERRY: api,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Recent release removed the deprecated method `async_setup_platforms` I have replaced it with the `await async_forward_entry_setups` and it works fine in local.