### PR TITLE
[codex] Add HBOS NG REST API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,45 +4,139 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0%201.0-lightgrey.svg)](http://creativecommons.org/publicdomain/zero/1.0/)
 
-The HiFiBerry HA integration allows controlling [HifiBerry OS](https://www.hifiberry.com/hifiberryos/) media players from Home Assistant.
+The HiFiBerry integration exposes a HiFiBerry OS player as a Home Assistant
+`media_player` entity.
 
-This is an end-to-end streaming lightweight OS built by HiFiBerry for their Amp+, DAC+ or Digi+ HAT Raspberry Pi boards compatible with AirPlay, Bluetooth, DLNA, LMS/Squeezebox, MPD, Snapcast, Spotify and Roon music services. This uses the [HiFiBerry audiocontrol2 socketio API](https://github.com/hifiberry/audiocontrol2/blob/master/doc/socketio_api.md).
- 
-***Be aware that this API is disabled by default. In order to use this integration it has to be enabled in the /etc/audiocontrol2.conf on the device, an authtoken will also have to be added:***
-```bash
-[webserver]
-enable=yes
-port=81
-socketio_enabled=True
-authtoken=[insert_custom_token_here]
+This version targets current HiFiBerry OS / HBOS NG builds that expose the
+AudioControl REST API through the web UI reverse proxy:
+
+```text
+http://<device>/api/audiocontrol/
 ```
 
-### Installation
+It no longer depends on the older `pyhifiberry` socket.io client.
 
-It is recommended this is installed using [Home Assistant Community Store (HACS)](https://hacs.xyz/) to ensure your Home Assistant instance can easily be kept up-to-date with the latest changes.
+## Supported Features
 
-However, to install this manually, copy everything from `/custom_components/hifiberry/` to your folder `<config directory>/custom_components/hifiberry/`.
+- Playback state, source, title, artist, album, and volume polling.
+- Play, pause, stop, and play/pause actions.
+- Dynamic control capabilities based on the active HiFiBerry player.
+- Spotify Connect, AirPlay/Shairport, MPD, Bluetooth, LMS, RAAT, and other
+  players as reported by HiFiBerry OS.
+- Album artwork lookup through the same cover-art API used by the HBOS NG web
+  UI.
 
-### Configuration
+Capabilities are source-specific. For example, AirPlay/Shairport usually reports
+play, pause, and stop, but not next/previous. Spotify and MPD may expose a wider
+set of controls.
 
-- Browse to your Home Assistant instance
-- In the sidebar click on  **Configuration**
-- From the configuration menu select: **Integrations**
-- In the bottom right, click on the **Add Integration** button
-- From the list, search and select “_HiFiBerry_”
-- Follow the instruction to complete the set up
+## Installation
 
-### Installation
+Install using [Home Assistant Community Store (HACS)](https://hacs.xyz/) where
+available.
 
-None required other than setting a fixed IP for the device running HiFiBerry.
+For manual installation, copy this folder:
 
-### Support
+```text
+custom_components/hifiberry/
+```
 
-There is no official support for this add-on and is community supported within the **[Home Assistant HiFiBerry discussion thread](https://community.home-assistant.io/t/hifiberry-os-media-player-integration/163567)**.
+to:
 
-If you have any proposed changes or bug fixes, please code them and create pull requests for your patches.
+```text
+<config directory>/custom_components/hifiberry/
+```
 
-### See Also
+Then fully restart Home Assistant.
 
-* [Home Assistant HiFiBerry discussion thread](https://community.home-assistant.io/t/hifiberry-os-media-player-integration/163567)
-* [pyhifiberry](https://github.com/schnabel/pyhifiberry)
+## Configuration
+
+1. Open Home Assistant.
+2. Go to **Settings** > **Devices & services**.
+3. Click **Add Integration**.
+4. Search for **HiFiBerry**.
+5. Enter the HiFiBerry host or IP address.
+6. Use port `80` for HBOS NG unless you have a custom reverse proxy.
+
+The old socket.io API token is no longer required.
+
+## Migration Notes
+
+This release moves the integration from the legacy HiFiBerry OS
+`audiocontrol2` socket.io API to the HBOS NG REST API.
+
+### Breaking Changes
+
+- The `pyhifiberry` dependency has been removed.
+- The old socket.io API on port `81` is no longer used.
+- The `authtoken` setup field has been removed for new config entries.
+- The integration is now local polling rather than local push.
+- Existing config entries may need their port changed to `80`.
+- Player controls are now source-specific. Buttons such as next/previous are
+  only exposed when the currently active HiFiBerry player reports support for
+  them.
+
+Existing entries that still contain an old `authtoken` value should continue to
+load, but the value is ignored.
+
+### HBOS NG API Details
+
+The integration uses:
+
+```text
+GET  /api/audiocontrol/now-playing
+GET  /api/audiocontrol/players
+POST /api/audiocontrol/player/<player_name>/command/<command>
+POST /api/audiocontrol/players/pause-all
+POST /api/audiocontrol/players/stop-all
+GET  /api/audiocontrol/coverart/...
+```
+
+Some HiFiBerry builds expose the backend on port `1080`, but the public and
+documented web UI route is usually port `80` with the `/api/audiocontrol/`
+prefix. The integration prefers the public route and keeps compatibility probes
+for older path shapes where practical.
+
+## Album Artwork
+
+HBOS NG does not always include artwork URLs in `now-playing`. The web UI performs
+a separate cover-art lookup using the current title, artist, and album. This
+integration mirrors that behavior and cleans common AirPlay metadata suffixes
+such as ` • Video Available` before querying cover-art providers.
+
+## Troubleshooting
+
+If the integration loads but controls are missing, inspect the entity attributes:
+
+```text
+hifiberry_active_player_name
+hifiberry_active_player_capabilities
+hifiberry_last_active_player_name
+hifiberry_cover_art_url
+hifiberry_now_playing
+```
+
+These show the active source, what commands HiFiBerry reports as supported, and
+the raw metadata returned by HBOS NG.
+
+If Home Assistant still appears to run an older version after updating, remove:
+
+```text
+<config directory>/custom_components/hifiberry/__pycache__/
+```
+
+and fully restart Home Assistant.
+
+## Support
+
+This is community-supported and is not an official HiFiBerry or Home Assistant
+integration.
+
+Discussion and support:
+
+- [Home Assistant HiFiBerry discussion thread](https://community.home-assistant.io/t/hifiberry-os-media-player-integration/163567)
+
+Related projects:
+
+- [HiFiBerry OS](https://www.hifiberry.com/hifiberryos/)
+- [HBOS NG backend API docs](https://github.com/hifiberry/hifiberry-os/blob/hbosng/docs/backend-apis.md)

--- a/custom_components/hifiberry/__init__.py
+++ b/custom_components/hifiberry/__init__.py
@@ -6,9 +6,10 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from pyhifiberry.audiocontrol2sio import Audiocontrol2SIO
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DATA_HIFIBERRY, DATA_INIT, DOMAIN
+from .audiocontrol import AudioControlClient
+from .const import DATA_HIFIBERRY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,10 +18,11 @@ PLATFORMS = ["media_player"]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up hifiberry from a config entry."""
+    host = entry.data["host"]
+    port = entry.data["port"]
+    api = AudioControlClient(async_get_clientsession(hass), host, port)
     try:
-        host=entry.data["host"]
-        port=entry.data["port"]
-        api = await Audiocontrol2SIO.connect(host, port)
+        await api.async_update()
     except Exception as error:
         raise ConfigEntryNotReady from error
 

--- a/custom_components/hifiberry/audiocontrol.py
+++ b/custom_components/hifiberry/audiocontrol.py
@@ -1,0 +1,339 @@
+"""Client for the HiFiBerry AudioControl REST API."""
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import Any
+from urllib.parse import quote
+
+from aiohttp import ClientError, ClientResponseError, ClientSession
+
+
+class AudioControlError(Exception):
+    """Raised when the AudioControl API cannot be reached."""
+
+
+class AudioControlClient:
+    """Small wrapper around the AudioControl REST API."""
+
+    def __init__(self, session: ClientSession, host: str, port: int) -> None:
+        """Initialize the client."""
+        self._session = session
+        self.host = host
+        self.port = port
+        self.base_url = f"http://{host}:{port}"
+        self.public_base_url = f"http://{host}"
+        self.connected = False
+        self.now_playing: dict[str, Any] = {}
+        self.players: list[dict[str, Any]] = []
+        self.volume: dict[str, Any] = {}
+        self.cover_art_url: str | None = None
+        self._cover_art_song_key: tuple[Any, Any, Any] | None = None
+        self._last_active_player_name: str | None = None
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Send a request to AudioControl."""
+        urls = [f"{self.base_url}{path}"]
+        if (
+            self.port != 80
+            and path.startswith(("/api/audiocontrol/", "/api/pipewire/"))
+        ):
+            urls.append(f"{self.public_base_url}{path}")
+        last_error: Exception | None = None
+        try:
+            for url in urls:
+                try:
+                    async with asyncio.timeout(10):
+                        response = await self._session.request(method, url, **kwargs)
+                        response.raise_for_status()
+                        if response.content_type == "application/json":
+                            return await response.json()
+                        return {}
+                except (TimeoutError, ClientError, ClientResponseError) as err:
+                    last_error = err
+            raise AudioControlError(f"Unable to call {urls[-1]}") from last_error
+        except (TimeoutError, ClientError, ClientResponseError) as err:
+            self.connected = False
+            raise AudioControlError(f"Unable to call {urls[-1]}") from err
+
+    async def _request_first(
+        self,
+        method: str,
+        paths: tuple[str, ...],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Try multiple API paths for compatibility across HiFiBerry OS builds."""
+        last_error: AudioControlError | None = None
+        for path in paths:
+            try:
+                return await self._request(method, path, **kwargs)
+            except AudioControlError as err:
+                last_error = err
+        if last_error is not None:
+            raise last_error
+        raise AudioControlError("No AudioControl API paths configured")
+
+    async def async_validate(self) -> None:
+        """Check that AudioControl is reachable."""
+        await self._request_first(
+            "GET",
+            (
+                "/api/version",
+                "/api/audiocontrol/version",
+                "/api/now-playing",
+                "/api/audiocontrol/now-playing",
+            ),
+        )
+        self.connected = True
+
+    async def async_update(self) -> None:
+        """Refresh cached player and volume data."""
+        self.now_playing = await self._request_first(
+            "GET",
+            (
+                "/api/now-playing",
+                "/api/audiocontrol/now-playing",
+            ),
+        )
+        try:
+            players_response = await self._request_first(
+                "GET",
+                (
+                    "/api/players",
+                    "/api/audiocontrol/players",
+                ),
+            )
+            players = players_response.get("players")
+            self.players = players if isinstance(players, list) else []
+        except AudioControlError:
+            self.players = []
+        try:
+            self.volume = await self._request_first(
+                "GET",
+                (
+                    "/api/volume/state",
+                    "/api/pipewire/v1/volume",
+                ),
+            )
+        except AudioControlError:
+            self.volume = {}
+        await self.async_update_cover_art()
+        active_player_name = self._active_player_name()
+        now_playing_state = str(self.now_playing.get("state") or "").lower()
+        if active_player_name and now_playing_state in ("playing", "paused", "pause"):
+            self._last_active_player_name = active_player_name
+        self.connected = True
+
+    def _song(self) -> dict[str, Any]:
+        """Return the current song payload."""
+        song = self.now_playing.get("song")
+        return song if isinstance(song, dict) else self.now_playing
+
+    @staticmethod
+    def _clean_artist(artist: Any) -> str | None:
+        """Clean AirPlay suffixes that break cover-art provider searches."""
+        if not isinstance(artist, str):
+            return None
+        artist = artist.split(" \u2022 ")[0].strip()
+        return artist or None
+
+    @staticmethod
+    def _base64_urlsafe(value: str) -> str:
+        """Encode strings the way the HiFiBerry Web UI cover-art loader does."""
+        encoded = base64.b64encode(value.encode()).decode()
+        return encoded.replace("+", "-").replace("/", "_").rstrip("=")
+
+    @staticmethod
+    def _best_cover_art_url(response: dict[str, Any]) -> str | None:
+        """Return the highest-grade cover-art URL from an API response."""
+        best_image: dict[str, Any] | None = None
+        for result in response.get("results") or []:
+            for image in result.get("images") or []:
+                if not isinstance(image, dict) or not image.get("url"):
+                    continue
+                if best_image is None:
+                    best_image = image
+                    continue
+                image_grade = image.get("grade") or 0
+                best_grade = best_image.get("grade") or 0
+                image_pixels = (image.get("width") or 0) * (image.get("height") or 0)
+                best_pixels = (best_image.get("width") or 0) * (best_image.get("height") or 0)
+                if (image_grade, image_pixels) > (best_grade, best_pixels):
+                    best_image = image
+        return best_image.get("url") if best_image else None
+
+    async def async_update_cover_art(self) -> None:
+        """Refresh cached cover art using the same API as the HiFiBerry Web UI."""
+        song = self._song()
+        title = song.get("title")
+        album = song.get("album")
+        artist = self._clean_artist(song.get("artist"))
+        song_key = (title, album, artist)
+
+        if song_key == self._cover_art_song_key:
+            return
+
+        self.cover_art_url = None
+        self._cover_art_song_key = song_key
+        if not artist:
+            return
+
+        lookups: list[tuple[str, ...]] = []
+        if isinstance(title, str) and title:
+            lookups.append(("song", title, artist))
+        if isinstance(album, str) and album:
+            lookups.append(("album", album, artist))
+        lookups.append(("artist", artist))
+
+        for lookup in lookups:
+            path = "/".join(self._base64_urlsafe(part) for part in lookup[1:])
+            try:
+                response = await self._request_first(
+                    "GET",
+                    (f"/api/audiocontrol/coverart/{lookup[0]}/{path}",),
+                )
+            except AudioControlError:
+                continue
+            cover_art_url = self._best_cover_art_url(response)
+            if cover_art_url:
+                self.cover_art_url = cover_art_url
+                return
+
+    def _active_player_name(self, command: str | None = None) -> str | None:
+        """Return the best active player name for a command."""
+        player = self.now_playing.get("player")
+        if isinstance(player, dict):
+            player_name = player.get("name")
+            capabilities = player.get("capabilities") or []
+            player_state = str(player.get("state") or self.now_playing.get("state") or "").lower()
+            if (
+                player_name
+                and player_state not in ("stopped", "unknown", "disconnected")
+                and (command is None or command in capabilities)
+            ):
+                return str(player_name)
+
+        active_players = [
+            player
+            for player in self.players
+            if player.get("is_active")
+            and str(player.get("state") or "").lower() not in ("unknown", "disconnected")
+        ]
+        if command is not None:
+            for player in active_players:
+                if command in (player.get("capabilities") or []) and player.get("name"):
+                    return str(player["name"])
+
+        for player in active_players:
+            if player.get("name"):
+                return str(player["name"])
+
+        return None
+
+    @property
+    def active_player_name(self) -> str | None:
+        """Return the current active player name."""
+        return self._active_player_name()
+
+    @property
+    def last_active_player_name(self) -> str | None:
+        """Return the last active player name used for resume."""
+        return self._last_active_player_name
+
+    @property
+    def active_player_capabilities(self) -> set[str]:
+        """Return capabilities reported by the active player."""
+        player = self.now_playing.get("player")
+        if isinstance(player, dict):
+            capabilities = player.get("capabilities")
+            if isinstance(capabilities, list):
+                return {str(capability) for capability in capabilities}
+
+        player_name = self.active_player_name
+        for player in self.players:
+            if player.get("name") != player_name:
+                continue
+            capabilities = player.get("capabilities")
+            if isinstance(capabilities, list):
+                return {str(capability) for capability in capabilities}
+
+        return set()
+
+    async def async_command(self, command: str) -> None:
+        """Send a playback command to the active player."""
+        if not self.now_playing:
+            await self.async_update()
+
+        if command == "play" and self._last_active_player_name:
+            player_name = self._last_active_player_name
+        else:
+            player_name = self._active_player_name(command)
+        paths = []
+        if command == "pause":
+            paths.append("/api/audiocontrol/players/pause-all")
+        elif command == "stop":
+            paths.append("/api/audiocontrol/players/stop-all")
+        if player_name:
+            quoted_player_name = quote(player_name, safe="")
+            paths.append(f"/api/audiocontrol/player/{quoted_player_name}/command/{command}")
+        elif command not in ("pause", "stop"):
+            raise AudioControlError(f"Active player does not support {command}")
+        try:
+            await self._request_first("POST", tuple(paths))
+        except AudioControlError:
+            if not await self._async_command_took_effect(command):
+                raise
+        self.connected = True
+
+    def _command_state_matches(self, command: str) -> bool:
+        """Return true if the current state already reflects a command."""
+        state = str(self.now_playing.get("state") or "").lower()
+        if command == "play":
+            return state == "playing"
+        if command == "pause":
+            return state in ("paused", "pause", "stopped", "stop")
+        if command == "stop":
+            return state in ("stopped", "stop")
+        return False
+
+    async def _async_command_took_effect(self, command: str) -> bool:
+        """Refresh state a few times to detect commands that worked despite errors."""
+        for _ in range(3):
+            await asyncio.sleep(0.5)
+            try:
+                await self.async_update()
+            except AudioControlError:
+                continue
+            if self._command_state_matches(command):
+                return True
+        return False
+
+    async def async_set_volume(self, percentage: float) -> None:
+        """Set the hardware volume percentage."""
+        response = await self._request_first(
+            "POST",
+            (
+                "/api/volume/set",
+                "/api/pipewire/v1/volume",
+            ),
+            json={"percentage": max(0.0, min(100.0, percentage))},
+        )
+        self.volume = response.get("new_state") or self.volume
+        self.connected = True
+
+    async def async_volume_up(self) -> None:
+        """Increase volume by the API default amount."""
+        response = await self._request("POST", "/api/volume/increase")
+        self.volume = response.get("new_state") or self.volume
+        self.connected = True
+
+    async def async_volume_down(self) -> None:
+        """Decrease volume by the API default amount."""
+        response = await self._request("POST", "/api/volume/decrease")
+        self.volume = response.get("new_state") or self.volume
+        self.connected = True

--- a/custom_components/hifiberry/config_flow.py
+++ b/custom_components/hifiberry/config_flow.py
@@ -8,10 +8,10 @@ import voluptuous as vol
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import DiscoveryInfoType
-from pyhifiberry.audiocontrol2sio import Audiocontrol2SIO
-from pyhifiberry.socketio_v5.exceptions import ConnectionError
 
+from .audiocontrol import AudioControlClient, AudioControlError
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,8 +19,14 @@ _LOGGER = logging.getLogger(__name__)
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
-    
-    await Audiocontrol2SIO.connect(host=data["host"], port=data["port"])
+
+    client = AudioControlClient(
+        async_get_clientsession(hass),
+        data["host"],
+        data["port"],
+    )
+    await client.async_validate()
+    return {"title": data["host"]}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -38,8 +44,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return vol.Schema(
             {
                 vol.Required("host", default=self.host): str,
-                vol.Optional("port", default=81): int,
-                vol.Optional("authtoken", default=""): str,
+                vol.Optional("port", default=80): int,
             }
         )
 
@@ -62,18 +67,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
 
-        await self.async_set_unique_id(user_input['host'])  # This should be future "rpi serial" from https://github.com/hifiberry/audiocontrol2/pull/17
+        await self.async_set_unique_id(user_input["host"])
         self._abort_if_unique_id_configured()
 
         try:
-            await validate_input(self.hass, user_input)
-        except ConnectionError:
+            info = await validate_input(self.hass, user_input)
+        except AudioControlError:
             errors["base"] = "cannot_connect"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            return self.async_create_entry(title=user_input["host"], data=user_input)
+            return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(
             step_id="user", data_schema=self.schema, errors=errors

--- a/custom_components/hifiberry/const.py
+++ b/custom_components/hifiberry/const.py
@@ -3,4 +3,3 @@
 DOMAIN = "hifiberry"
 
 DATA_HIFIBERRY = "hifiberry"
-DATA_INIT = "initial values"

--- a/custom_components/hifiberry/manifest.json
+++ b/custom_components/hifiberry/manifest.json
@@ -3,12 +3,13 @@
     "name": "HiFiBerry",
     "config_flow": true,
     "documentation": "https://github.com/willholdoway/hifiberry",
-    "requirements": ["pyhifiberry>=0.1.1"],
+    "integration_type": "hub",
+    "requirements": [],
     "zeroconf": [
         {"type": "_mpd._tcp.local.", "name": "music player*"}
     ],
     "dependencies": [],
     "codeowners": ["@willholdoway", "@dgomes"],
-    "version": "0.0.3",
-    "iot_class": "local_push"
+    "version": "0.1.11",
+    "iot_class": "local_polling"
 }

--- a/custom_components/hifiberry/media_player.py
+++ b/custom_components/hifiberry/media_player.py
@@ -1,71 +1,102 @@
-"""Hifiberry Platform."""
-import logging
+"""HiFiBerry media player platform."""
+from __future__ import annotations
+
 from datetime import timedelta
+import logging
+from typing import Any
 
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import MediaType
 from homeassistant.components.media_player import MediaPlayerEntityFeature
+from homeassistant.const import STATE_IDLE, STATE_PAUSED, STATE_PLAYING
 
-from homeassistant.const import (
-    STATE_IDLE,
-    STATE_PAUSED,
-    STATE_PLAYING,
-)
-from pyhifiberry.audiocontrol2 import Audiocontrol2Exception, LOGGER
-from pyhifiberry.audiocontrol2sio import Audiocontrol2SIO
-from .const import DATA_HIFIBERRY, DATA_INIT, DOMAIN
-
-from homeassistant.components.media_player import MediaPlayerEntityFeature
-SUPPORT_HIFIBERRY = (
-    MediaPlayerEntityFeature.PAUSE |
-    MediaPlayerEntityFeature.VOLUME_SET |
-    MediaPlayerEntityFeature.VOLUME_MUTE |
-    MediaPlayerEntityFeature.PREVIOUS_TRACK |
-    MediaPlayerEntityFeature.NEXT_TRACK |
-    MediaPlayerEntityFeature.STOP |
-    MediaPlayerEntityFeature.PLAY |
-    MediaPlayerEntityFeature.VOLUME_STEP |
-    MediaPlayerEntityFeature.TURN_OFF
-)
+from .audiocontrol import AudioControlClient, AudioControlError
+from .const import DATA_HIFIBERRY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+SCAN_INTERVAL = timedelta(seconds=5)
+
+SUPPORT_VOLUME = (
+    MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.VOLUME_MUTE
+    | MediaPlayerEntityFeature.VOLUME_STEP
+)
+
+CAPABILITY_TO_FEATURE = {
+    "play": MediaPlayerEntityFeature.PLAY,
+    "pause": MediaPlayerEntityFeature.PAUSE,
+    "stop": MediaPlayerEntityFeature.STOP,
+    "previous": MediaPlayerEntityFeature.PREVIOUS_TRACK,
+    "next": MediaPlayerEntityFeature.NEXT_TRACK,
+}
+
+PLAY_PAUSE_FEATURES = (
+    MediaPlayerEntityFeature.PLAY
+    | MediaPlayerEntityFeature.PAUSE
+)
+
+SUPPORT_HIFIBERRY_FALLBACK = (
+    MediaPlayerEntityFeature.PAUSE
+    | MediaPlayerEntityFeature.STOP
+    | MediaPlayerEntityFeature.PLAY
+    | SUPPORT_VOLUME
+)
+
+if hasattr(MediaPlayerEntityFeature, "TURN_ON"):
+    SUPPORT_HIFIBERRY_FALLBACK |= MediaPlayerEntityFeature.TURN_ON
+
+if hasattr(MediaPlayerEntityFeature, "TURN_OFF"):
+    SUPPORT_HIFIBERRY_FALLBACK |= MediaPlayerEntityFeature.TURN_OFF
+
+
+def _first_value(data: dict[str, Any], *keys: str) -> Any:
+    """Return the first non-empty value from a dict."""
+    for key in keys:
+        value = data.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _nested_first_value(data: dict[str, Any], *keys: str) -> Any:
+    """Return the first non-empty value from now-playing or nested song data."""
+    song = data.get("song")
+    if isinstance(song, dict):
+        value = _first_value(song, *keys)
+        if value is not None:
+            return value
+    return _first_value(data, *keys)
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the hifiberry media player platform."""
+    """Set up the HiFiBerry media player platform."""
 
     data = hass.data[DOMAIN][config_entry.entry_id]
-    audiocontrol2 = data[DATA_HIFIBERRY]
+    audiocontrol = data[DATA_HIFIBERRY]
     uid = config_entry.entry_id
-    name = f"hifiberry {config_entry.data['host']}"
-    base_url = f"http://{config_entry.data['host']}:{config_entry.data['port']}"
-    entity = HifiberryMediaPlayer(audiocontrol2, uid, name, base_url)
-    async_add_entities([entity])
+    name = f"HiFiBerry {config_entry.data['host']}"
+    entity = HifiberryMediaPlayer(audiocontrol, uid, name)
+    async_add_entities([entity], update_before_add=True)
 
 
 class HifiberryMediaPlayer(MediaPlayerEntity):
-    """Hifiberry Media Player Object."""
+    """HiFiBerry media player object."""
 
-    should_poll = False
+    should_poll = True
 
-    def __init__(self, audiocontrol2: Audiocontrol2SIO, uid, name, base_url):
+    def __init__(self, audiocontrol: AudioControlClient, uid: str, name: str) -> None:
         """Initialize the media player."""
-        self._audiocontrol2 = audiocontrol2
-        self._uid = uid
-        self._name = name
-        self._base_url = base_url
-        self._muted = audiocontrol2.volume.percent == 0
-        self._muted_volume = audiocontrol2.volume.percent
+        self._audiocontrol = audiocontrol
+        self._attr_unique_id = uid
+        self._attr_name = name
+        self._muted = False
+        self._muted_volume = 50
 
     @property
     def available(self) -> bool:
         """Return true if device is responding."""
-        return self._audiocontrol2.connected
-
-    @property
-    def unique_id(self):
-        """Return the unique id for the entity."""
-        return self._uid
+        return self._audiocontrol.connected
 
     @property
     def device_info(self):
@@ -73,18 +104,8 @@ class HifiberryMediaPlayer(MediaPlayerEntity):
         return {
             "identifiers": {(DOMAIN, self.unique_id)},
             "name": self.name,
-            "manufacturer": "Hifiberry",
+            "manufacturer": "HiFiBerry",
         }
-
-    async def async_added_to_hass(self) -> None:
-        """Run when this Entity has been added to HA."""
-        await self._audiocontrol2.volume.get()      ### make sure volume percent is set
-        self._audiocontrol2.metadata.add_callback(self.schedule_update_ha_state)
-        self._audiocontrol2.volume.add_callback(self.schedule_update_ha_state)
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Entity being removed from hass."""
-        await self._audiocontrol2.disconnect()
 
     @property
     def media_content_type(self):
@@ -92,65 +113,153 @@ class HifiberryMediaPlayer(MediaPlayerEntity):
         return MediaType.MUSIC
 
     @property
+    def supported_features(self):
+        """Return features supported by the active player."""
+        capabilities = self._audiocontrol.active_player_capabilities
+        if not capabilities:
+            return SUPPORT_HIFIBERRY_FALLBACK
+
+        features = SUPPORT_VOLUME
+        for capability, feature in CAPABILITY_TO_FEATURE.items():
+            if capability in capabilities:
+                features |= feature
+        if "play_pause" in capabilities:
+            features |= PLAY_PAUSE_FEATURES
+        if "play" in capabilities:
+            if hasattr(MediaPlayerEntityFeature, "TURN_ON"):
+                features |= MediaPlayerEntityFeature.TURN_ON
+        if "stop" in capabilities or "pause" in capabilities:
+            if hasattr(MediaPlayerEntityFeature, "TURN_OFF"):
+                features |= MediaPlayerEntityFeature.TURN_OFF
+        return features
+
+    @property
     def state(self):
         """Return the state of the device."""
-        status = self._audiocontrol2.metadata.playerState
-        if status == "paused":
+        status = str(
+            _first_value(
+                self._audiocontrol.now_playing,
+                "state",
+                "playerState",
+                "player_state",
+                "status",
+            )
+            or ""
+        ).lower()
+        if status in ("paused", "pause"):
             return STATE_PAUSED
-        if status == "playing":
+        if status in ("playing", "play"):
             return STATE_PLAYING
         return STATE_IDLE
 
     @property
-    def media_position_updated_at(self):
-        """When was the position of the current playing media valid.
-
-        Returns value from homeassistant.util.dt.utcnow().
-        """
-        return self._audiocontrol2.metadata.positionupdate
-        
-    @property
     def media_title(self):
         """Title of current playing media."""
-        return self._audiocontrol2.metadata.title
+        return _nested_first_value(
+            self._audiocontrol.now_playing,
+            "title",
+            "name",
+            "song_title",
+        )
 
     @property
     def media_artist(self):
-        """Artist of current playing media (Music track only)."""
-        return self._audiocontrol2.metadata.artist
+        """Artist of current playing media."""
+        return _nested_first_value(
+            self._audiocontrol.now_playing,
+            "artist",
+            "song_artist",
+        )
 
     @property
     def media_album_name(self):
-        """Artist of current playing media (Music track only)."""
-        return self._audiocontrol2.metadata.albumTitle
+        """Album of current playing media."""
+        return _nested_first_value(
+            self._audiocontrol.now_playing,
+            "album",
+            "albumTitle",
+            "album_title",
+        )
 
     @property
     def media_album_artist(self):
-        """Album artist of current playing media, music track only."""
-        return self._audiocontrol2.metadata.albumArtist
+        """Album artist of current playing media."""
+        return _nested_first_value(
+            self._audiocontrol.now_playing,
+            "albumArtist",
+            "album_artist",
+        )
 
     @property
     def media_track(self):
-        """Track number of current playing media, music track only."""
-        return self._audiocontrol2.metadata.tracknumber
+        """Track number of current playing media."""
+        return _nested_first_value(
+            self._audiocontrol.now_playing,
+            "track",
+            "tracknumber",
+            "track_number",
+        )
 
     @property
     def media_image_url(self):
-        """Image url of current playing media."""
-        art_url = self._audiocontrol2.metadata.artUrl
-        external_art_url = self._audiocontrol2.metadata.externalArtUrl
-        if art_url is not None:
-            if art_url.startswith("static/"):
-                return external_art_url
+        """Image URL of current playing media."""
+        art_url = _nested_first_value(
+            self._audiocontrol.now_playing,
+            "artUrl",
+            "art_url",
+            "artwork",
+            "image",
+            "image_url",
+            "coverart",
+            "coverart_url",
+            "album_art",
+            "album_art_url",
+            "cover",
+            "cover_url",
+        )
+        if art_url is None:
+            art_url = self._audiocontrol.cover_art_url
+        if isinstance(art_url, str) and art_url.startswith("/"):
+            base_url = (
+                self._audiocontrol.public_base_url
+                if art_url.startswith("/api/")
+                else self._audiocontrol.base_url
+            )
+            return f"{base_url}{art_url}"
+        if isinstance(art_url, str) and not art_url.startswith(("http://", "https://")):
             if art_url.startswith("artwork/"):
-                return f"{self._base_url}/{art_url}"
-            return art_url
-        return external_art_url
+                return f"{self._audiocontrol.base_url}/api/{art_url}"
+            return f"{self._audiocontrol.base_url}/{art_url}"
+        return art_url
+
+    @property
+    def extra_state_attributes(self):
+        """Expose raw AudioControl data for troubleshooting metadata/artwork."""
+        return {
+            "hifiberry_now_playing": self._audiocontrol.now_playing,
+            "hifiberry_active_player_name": self._audiocontrol.active_player_name,
+            "hifiberry_last_active_player_name": (
+                self._audiocontrol.last_active_player_name
+            ),
+            "hifiberry_active_player_capabilities": sorted(
+                self._audiocontrol.active_player_capabilities
+            ),
+            "hifiberry_cover_art_url": self._audiocontrol.cover_art_url,
+            "hifiberry_media_image_url": self.media_image_url,
+        }
 
     @property
     def volume_level(self):
         """Volume level of the media player (0..1)."""
-        return int(self._audiocontrol2.volume.percent) / 100
+        percent = _first_value(
+            self._audiocontrol.volume,
+            "percentage",
+            "percent",
+            "volume",
+        )
+        if percent is None:
+            return None
+        return float(percent) / 100
 
     @property
     def is_volume_muted(self):
@@ -158,60 +267,88 @@ class HifiberryMediaPlayer(MediaPlayerEntity):
         return self._muted
 
     @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
-
-    @property
     def source(self):
         """Name of the current input source."""
-        return self._audiocontrol2.metadata.playerName
+        player = self._audiocontrol.now_playing.get("player")
+        if isinstance(player, dict):
+            return _first_value(player, "name", "id")
+        return _first_value(
+            self._audiocontrol.now_playing,
+            "player",
+            "playerName",
+            "player_name",
+            "source",
+        )
 
-    @property
-    def supported_features(self):
-        """Flag of media commands that are supported."""
-        return SUPPORT_HIFIBERRY
+    async def async_update(self):
+        """Refresh state from AudioControl."""
+        try:
+            await self._audiocontrol.async_update()
+        except AudioControlError:
+            _LOGGER.debug("Unable to update HiFiBerry state", exc_info=True)
 
     async def async_media_next_track(self):
         """Send media_next command to media player."""
-        await self._audiocontrol2.player.next()
+        await self._audiocontrol.async_command("next")
 
     async def async_media_previous_track(self):
         """Send media_previous command to media player."""
-        await self._audiocontrol2.player.previous()
+        await self._audiocontrol.async_command("previous")
 
     async def async_media_play(self):
         """Send media_play command to media player."""
-        await self._audiocontrol2.player.play()
+        await self._audiocontrol.async_command("play")
 
     async def async_media_pause(self):
         """Send media_pause command to media player."""
-        await self._audiocontrol2.player.pause()
+        await self._audiocontrol.async_command("pause")
+
+    async def async_media_play_pause(self):
+        """Toggle play/pause state."""
+        try:
+            await self._audiocontrol.async_update()
+        except AudioControlError:
+            _LOGGER.debug("Unable to refresh HiFiBerry state before toggle", exc_info=True)
+        if self.state == STATE_PLAYING:
+            await self._audiocontrol.async_command("pause")
+        else:
+            await self._audiocontrol.async_command("play")
+
+    async def async_turn_on(self):
+        """Turn the media player on by starting playback."""
+        await self._audiocontrol.async_command("play")
+
+    async def async_turn_off(self):
+        """Turn the media player off by stopping playback."""
+        await self._audiocontrol.async_command("stop")
+
+    async def async_toggle(self):
+        """Toggle playback for Home Assistant's media_player.toggle action."""
+        await self.async_media_play_pause()
+
+    async def async_media_stop(self):
+        """Send media_stop command to media player."""
+        await self._audiocontrol.async_command("stop")
 
     async def async_volume_up(self):
-        """Service to send the hifiberry the command for volume up."""
-        await self._audiocontrol2.volume.set(min(100, self._audiocontrol2.volume.percent + 5))
+        """Service to send the HiFiBerry the command for volume up."""
+        await self._audiocontrol.async_volume_up()
 
     async def async_volume_down(self):
-        """Service to send the hifiberry the command for volume down."""
-        await self._audiocontrol2.volume.set(max(0, self._audiocontrol2.volume.percent - 5))
+        """Service to send the HiFiBerry the command for volume down."""
+        await self._audiocontrol.async_volume_down()
 
     async def async_set_volume_level(self, volume):
         """Send volume_set command to media player."""
-        if volume < 0:
-            volume = 0
-        elif volume > 1:
-            volume = 1
-        await self._audiocontrol2.volume.set(int(volume * 100))
-        self._volume = volume * 100
+        await self._audiocontrol.async_set_volume(volume * 100)
 
     async def async_mute_volume(self, mute):
-        """Mute. Emulated with set_volume_level."""
+        """Mute, emulated by setting volume to 0."""
         if mute:
-            self._muted_volume = self.volume_level * 100
-            await self._audiocontrol2.volume.set(0)
-        await self._audiocontrol2.volume.set(int(self._muted_volume))
+            current_volume = self.volume_level
+            if current_volume is not None:
+                self._muted_volume = current_volume * 100
+            await self._audiocontrol.async_set_volume(0)
+        else:
+            await self._audiocontrol.async_set_volume(self._muted_volume)
         self._muted = mute
-
-    async def async_turn_off(self):
-        return await self._audiocontrol2.poweroff()

--- a/custom_components/hifiberry/strings.json
+++ b/custom_components/hifiberry/strings.json
@@ -5,8 +5,7 @@
             "user": {
                 "data": {
                     "host": "[%key:common::config_flow::data::host%]",
-                    "port": "[%key:common::config_flow::data::port%]",
-                    "authtoken": "authtoken"
+                    "port": "[%key:common::config_flow::data::port%]"
                 }
             }
         },

--- a/custom_components/hifiberry/translations/en.json
+++ b/custom_components/hifiberry/translations/en.json
@@ -12,8 +12,7 @@
             "user": {
                 "data": {
                     "host": "Host",
-                    "port": "Port",
-                    "authtoken": "authtoken"
+                    "port": "Port"
                 }
             }
         }


### PR DESCRIPTION
## Summary

Migrates the HiFiBerry custom integration from the legacy `pyhifiberry` / `audiocontrol2` socket.io client to the current HBOS NG AudioControl REST API.

## What Changed

- Adds a local `AudioControlClient` for HBOS NG REST endpoints.
- Switches setup and validation to Home Assistant's shared aiohttp session.
- Removes the `pyhifiberry` runtime dependency.
- Changes the integration from local push to local polling.
- Reads state and metadata from `/api/audiocontrol/now-playing`.
- Reads active player capabilities from `/api/audiocontrol/players`.
- Exposes controls dynamically based on the active player capabilities.
- Uses HBOS NG command endpoints for player-specific commands plus `pause-all` / `stop-all`.
- Adds tolerance for command endpoints that report an error after the action has taken effect.
- Adds album-art lookup through the HBOS NG cover-art API, matching the web UI behavior.
- Updates README and HACS metadata for HBOS NG setup and migration notes.

## Breaking Changes / Migration Notes

- The old socket.io API on port `81` is no longer used.
- The `authtoken` setup field is removed for new config entries.
- Existing config entries may need to change their port to `80`.
- The integration now polls instead of receiving socket.io push updates.
- Player controls are source-specific; next/previous only appear when the active HiFiBerry player reports support for them.

Existing config entries that still include `authtoken` should continue to load, but the value is ignored.

## Validation

- Tested against a live HBOS NG device.
- Verified metadata from `/api/audiocontrol/now-playing`.
- Verified cover art via `/api/audiocontrol/coverart/...`.
- Verified pause/stop with aggregate HBOS NG command endpoints.
- Verified Spotify playback control behavior through Home Assistant.
- Ran Python syntax compilation for the integration files.
- Ran `git diff --check`.

## Follow-Ups

- Consider adding automated tests around the REST client path selection and command fallback behavior.
- Consider adding config-entry migration logic if existing users commonly have port `81` or `1080` saved.
